### PR TITLE
chore: gitignore local python env files

### DIFF
--- a/pretext/.gitignore
+++ b/pretext/.gitignore
@@ -11,6 +11,11 @@ generated-assets
 # don't track node packages
 node_modules
 
+# don't track local Python environments/caches
+.venv/
+__pycache__/
+*.py[cod]
+
 # don't track error logs
 .error_schema.log
 cli.log


### PR DESCRIPTION
My local diffs were showing changes to 5000+ files after generating the textbook. This was because all locally generated python env files were being committed to git, which is not necessary. This PR updates the .gitignore file to exclude these files.